### PR TITLE
Add authentication and shareable guide flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+client/dist
+server/dist
+.env

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.9.0",
         "react": "^18.3.1",
         "react-beautiful-dnd": "^13.1.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1045,6 +1046,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3434,6 +3444,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redux": {

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.9.0",
     "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,42 +1,372 @@
 #root {
-  max-width: 1280px;
+  min-height: 100vh;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 2.5rem;
+  color: #1d3dea;
+}
+
+.app-subtitle {
+  margin: 0.5rem 0 2rem;
+  color: #475467;
+}
+
+.auth-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: #ffffff;
+  box-shadow: 0 24px 80px rgba(61, 83, 255, 0.12);
+  text-align: left;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #344054;
+}
+
+.form-field input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  font-size: 1rem;
+  background-color: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: #1d3dea;
+  box-shadow: 0 0 0 4px rgba(66, 120, 255, 0.12);
+  background: #ffffff;
+}
+
+.primary-button,
+.secondary-button,
+.link-button {
+  cursor: pointer;
+  border: none;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary-button {
+  padding: 0.85rem 1.25rem;
+  background: linear-gradient(135deg, #1d3dea, #5b67ff);
+  color: white;
+  box-shadow: 0 18px 30px rgba(29, 61, 234, 0.25);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 34px rgba(29, 61, 234, 0.32);
+}
+
+.primary-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.secondary-button {
+  padding: 0.75rem 1.1rem;
+  background: #eef2ff;
+  color: #1d3dea;
+  border: 1px solid rgba(29, 61, 234, 0.2);
+}
+
+.secondary-button:hover {
+  background: #e0e7ff;
+}
+
+.link-button {
+  background: none;
+  color: #1d3dea;
+  padding: 0;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.link-button.danger {
+  color: #f04438;
+}
+
+.form-error {
+  margin: 0;
+  color: #f04438;
+  font-weight: 500;
+}
+
+.auth-switch {
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+  color: #475467;
+}
+
+.dashboard {
+  max-width: 1100px;
   margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.dashboard-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #1d2939;
+}
+
+.dashboard-header p {
+  margin: 0.25rem 0 0;
+  color: #475467;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.builder-card,
+.guides-card,
+.public-card {
+  background: #ffffff;
+  border-radius: 24px;
   padding: 2rem;
+  box-shadow: 0 20px 60px rgba(15, 35, 95, 0.12);
+}
+
+.builder-card h2,
+.guides-card h2,
+.public-card h1 {
+  margin-top: 0;
+  color: #1d2939;
+}
+
+.builder-description {
+  margin-bottom: 1.5rem;
+  color: #475467;
+}
+
+.row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.row input {
+  flex: 1;
+}
+
+.sections-list {
+  min-height: 160px;
+  border: 1px dashed #d0d5dd;
+  border-radius: 16px;
+  padding: 1rem;
+  background: #f8f9ff;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sections-placeholder {
+  margin: 0;
+  color: #667085;
+  font-style: italic;
+}
+
+.section-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: white;
+  border: 1px solid #e0e7ff;
+  box-shadow: 0 8px 18px rgba(29, 61, 234, 0.08);
+}
+
+.section-item span {
+  flex: 1;
+  text-align: left;
+  color: #1d2939;
+}
+
+.guides-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.guides-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.guides-list {
+  list-style: none;
+  display: grid;
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
+}
+
+.guides-item {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid #e4e7ec;
+  background: #f9fafb;
+}
+
+.guide-meta {
+  margin: 0.5rem 0;
+  color: #667085;
+}
+
+.guide-actions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.guide-actions input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #d0d5dd;
+  background: white;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.9rem;
+}
+
+.share-label {
+  font-size: 0.85rem;
+  color: #475467;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.success-banner,
+.error-banner {
+  padding: 0.85rem 1.1rem;
+  border-radius: 14px;
+  margin-bottom: 1.5rem;
+  font-weight: 500;
+}
+
+.success-banner {
+  background: #ecfdf3;
+  color: #027a48;
+  border: 1px solid #a6f4c5;
+}
+
+.error-banner {
+  background: #fef3f2;
+  color: #b42318;
+  border: 1px solid #fecdca;
+}
+
+.public-wrapper {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.public-card {
+  width: min(720px, 100%);
+}
+
+.public-header {
   text-align: center;
+  margin-bottom: 2.5rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.public-header h1 {
+  font-size: 2.2rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.public-host {
+  margin: 0.5rem 0 0;
+  color: #344054;
+}
+
+.public-updated {
+  margin: 0.25rem 0 0;
+  color: #667085;
+  font-size: 0.95rem;
+}
+
+.public-sections {
+  list-style: none;
+  display: grid;
+  gap: 1.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.public-sections li {
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid #e0e7ff;
+  background: #f9fbff;
+  box-shadow: 0 18px 30px rgba(29, 61, 234, 0.08);
+}
+
+.public-sections h2 {
+  margin: 0 0 0.75rem;
+  color: #1d3dea;
+}
+
+.public-sections p {
+  margin: 0;
+  color: #475467;
+}
+
+@media (max-width: 720px) {
+  .dashboard {
+    padding: 2rem 1.25rem 3rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .auth-card,
+  .builder-card,
+  .guides-card,
+  .public-card {
+    border-radius: 18px;
+    padding: 1.75rem;
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,162 +1,485 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+  useParams,
+} from 'react-router-dom';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import './index.css';
+import './App.css';
 
-function App() {
-  const [guides, setGuides] = useState([]);
-  const [title, setTitle] = useState('');
-  const [elements, setElements] = useState([]); // Elementer i dra-og-slipp-editoren
-  const [newElement, setNewElement] = useState(''); // Input for å legge til nytt element
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
 
-  // Hent guider fra backend når komponenten lastes
-  useEffect(() => {
-    axios.get('http://localhost:5000/api/guides')
-      .then((response) => {
-        setGuides(response.data);
-      })
-      .catch((error) => {
-        console.error('Feil ved henting av guider:', error);
-      });
-  }, []);
+const api = axios.create({
+  baseURL: API_BASE_URL,
+});
 
-  // Håndter dra-og-slipp
-  const handleDragEnd = (result) => {
-    if (!result.destination) return; // Hvis elementet slippes utenfor en droppable
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    // eslint-disable-next-line no-param-reassign
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
 
-    const reorderedElements = [...elements];
-    const [movedElement] = reorderedElements.splice(result.source.index, 1);
-    reorderedElements.splice(result.destination.index, 0, movedElement);
-    setElements(reorderedElements);
+const createElementId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const AuthView = ({ onSuccess }) => {
+  const [mode, setMode] = useState('login');
+  const [formValues, setFormValues] = useState({ name: '', email: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const toggleMode = () => {
+    setMode((prev) => (prev === 'login' ? 'register' : 'login'));
+    setError('');
   };
 
-  // Legg til nytt element i guiden
-  const addElement = (e) => {
-    e.preventDefault();
-    if (!newElement) return;
-    setElements([...elements, { id: `${elements.length + 1}`, content: newElement }]);
-    setNewElement('');
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((prev) => ({ ...prev, [name]: value }));
   };
 
-  // Lagre guiden til backend
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!title || elements.length === 0) return;
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
 
-    const content = elements.map((el) => el.content).join('\n'); // Kombiner elementer til en streng
-    axios.post('http://localhost:5000/api/guides', { title, content })
-      .then((response) => {
-        setGuides([...guides, response.data]); // Legg til ny guide i listen
-        setTitle(''); // Tøm skjemaet
-        setElements([]);
-      })
-      .catch((error) => {
-        console.error('Feil ved lagring av guide:', error);
-      });
+    try {
+      setLoading(true);
+      const endpoint = mode === 'login' ? '/auth/login' : '/auth/register';
+      const payload = mode === 'login'
+        ? { email: formValues.email, password: formValues.password }
+        : {
+          name: formValues.name,
+          email: formValues.email,
+          password: formValues.password,
+        };
+
+      const { data } = await api.post(endpoint, payload);
+      onSuccess(data);
+    } catch (err) {
+      const message = err.response?.data?.message || 'Noe gikk galt. Prøv igjen.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-3xl text-center mb-4">Guidebook SaaS</h1>
+    <div className="auth-wrapper">
+      <div className="auth-card">
+        <h1 className="app-title">Guidebook</h1>
+        <p className="app-subtitle">Din digitale vertsbok for Airbnb, hotell og ferieboliger.</p>
 
-      {/* Dra-og-slipp-editor */}
-      <form onSubmit={handleSubmit} className="mb-8">
-        <div className="mb-4">
-          <label className="block text-gray-700">Tittel</label>
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="w-full p-2 border rounded"
-            required
-          />
-        </div>
+        <form onSubmit={handleSubmit} className="auth-form">
+          {mode === 'register' && (
+            <label className="form-field">
+              <span>Navn</span>
+              <input
+                name="name"
+                type="text"
+                value={formValues.name}
+                onChange={handleChange}
+                placeholder="Navnet som vises til gjestene dine"
+                required
+              />
+            </label>
+          )}
 
-        <div className="mb-4">
-          <label className="block text-gray-700">Legg til element</label>
-          <div className="flex gap-2">
+          <label className="form-field">
+            <span>E-post</span>
             <input
-              type="text"
-              value={newElement}
-              onChange={(e) => setNewElement(e.target.value)}
-              className="w-full p-2 border rounded"
-              placeholder="Skriv inn tekst..."
+              name="email"
+              type="email"
+              value={formValues.email}
+              onChange={handleChange}
+              placeholder="din@bedrift.no"
+              required
             />
-            <button
-              type="button"
-              onClick={addElement}
-              className="bg-green-500 text-white p-2 rounded"
-            >
-              Legg til
-            </button>
-          </div>
-        </div>
+          </label>
 
-        {/* Dra-og-slipp-liste */}
-        <DragDropContext onDragEnd={handleDragEnd}>
-          <Droppable droppableId="elements">
-            {(provided) => (
-              <div
-                {...provided.droppableProps}
-                ref={provided.innerRef}
-                className="min-h-[100px] p-4 border rounded mb-4"
-              >
-                {elements.length === 0 ? (
-                  <p className="text-gray-500">Legg til elementer...</p>
-                ) : (
-                  elements.map((element, index) => (
-                    <Draggable key={element.id} draggableId={element.id} index={index}>
-                      {(provided) => (
-                        <div
-                          ref={provided.innerRef}
-                          {...provided.draggableProps}
-                          {...provided.dragHandleProps}
-                          className="p-2 mb-2 bg-gray-100 border rounded flex justify-between items-center"
-                        >
-                          <span>{element.content}</span>
-                          <button
-                            onClick={() => setElements(elements.filter((el) => el.id !== element.id))}
-                            className="text-red-500 hover:text-red-700"
-                          >
-                            Slett
-                          </button>
-                        </div>
-                      )}
-                    </Draggable>
-                  ))
-                )}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
+          <label className="form-field">
+            <span>Passord</span>
+            <input
+              name="password"
+              type="password"
+              value={formValues.password}
+              onChange={handleChange}
+              placeholder="Minst 6 tegn"
+              required
+            />
+          </label>
 
-        <button type="submit" className="bg-blue-500 text-white p-2 rounded">
-          Lagre guide
-        </button>
-      </form>
+          {error && <p className="form-error">{error}</p>}
 
-      {/* Vis liste over guider */}
-      <div>
-        <h2 className="text-2xl mb-4">Dine guider</h2>
-        {guides.length === 0 ? (
-          <p>Ingen guider ennå.</p>
-        ) : (
-          <ul>
-            {guides.map((guide) => (
-              <li key={guide._id} className="mb-4 p-4 border rounded">
-                <h3 className="text-xl">{guide.title}</h3>
-                <p>{guide.content}</p>
-                <p className="text-gray-500 text-sm">
-                  Opprettet: {new Date(guide.createdAt).toLocaleString()}
-                </p>
-              </li>
-            ))}
-          </ul>
-        )}
+          <button type="submit" className="primary-button" disabled={loading}>
+            {loading ? 'Sender...' : mode === 'login' ? 'Logg inn' : 'Opprett konto'}
+          </button>
+        </form>
+
+        <p className="auth-switch">
+          {mode === 'login' ? 'Har du ikke en konto?' : 'Har du allerede en konto?'}
+          {' '}
+          <button type="button" onClick={toggleMode} className="link-button">
+            {mode === 'login' ? 'Registrer deg her' : 'Logg inn'}
+          </button>
+        </p>
       </div>
     </div>
   );
-}
+};
+
+const GuideBuilder = ({ onCreate }) => {
+  const [title, setTitle] = useState('');
+  const [elements, setElements] = useState([]);
+  const [newElement, setNewElement] = useState('');
+  const [error, setError] = useState('');
+
+  const handleDragEnd = (result) => {
+    if (!result.destination) return;
+
+    const reordered = Array.from(elements);
+    const [moved] = reordered.splice(result.source.index, 1);
+    reordered.splice(result.destination.index, 0, moved);
+    setElements(reordered);
+  };
+
+  const handleAddElement = () => {
+    if (!newElement.trim()) {
+      return;
+    }
+
+    setElements((prev) => [
+      ...prev,
+      {
+        id: createElementId(),
+        content: newElement.trim(),
+      },
+    ]);
+    setNewElement('');
+  };
+
+  const handleRemoveElement = (id) => {
+    setElements((prev) => prev.filter((element) => element.id !== id));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+
+    if (!title.trim()) {
+      setError('Skriv inn en tittel for guiden.');
+      return;
+    }
+
+    if (elements.length === 0) {
+      setError('Legg til minst én seksjon før du lagrer.');
+      return;
+    }
+
+    try {
+      const sections = elements.map((element) => element.content);
+      await onCreate({ title: title.trim(), sections });
+      setTitle('');
+      setElements([]);
+      setNewElement('');
+    } catch (err) {
+      setError(err.message || 'Kunne ikke lagre guiden');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="builder-card">
+      <h2>Lag en ny guide</h2>
+      <p className="builder-description">
+        Sett sammen en flott digital guide ved å legge til de viktigste detaljene gjestene dine trenger.
+      </p>
+
+      <label className="form-field">
+        <span>Tittel</span>
+        <input
+          type="text"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          placeholder="F.eks. Velkommen til Solsiden Lodge"
+          required
+        />
+      </label>
+
+      <label className="form-field">
+        <span>Legg til seksjon</span>
+        <div className="row">
+          <input
+            type="text"
+            value={newElement}
+            onChange={(event) => setNewElement(event.target.value)}
+            placeholder="Husregler, WiFi-informasjon, anbefalte restauranter..."
+          />
+          <button type="button" onClick={handleAddElement} className="secondary-button">
+            Legg til
+          </button>
+        </div>
+      </label>
+
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <Droppable droppableId="sections">
+          {(provided) => (
+            <div className="sections-list" ref={provided.innerRef} {...provided.droppableProps}>
+              {elements.length === 0 && <p className="sections-placeholder">Ingen seksjoner enda. Legg til innhold for å komme i gang.</p>}
+              {elements.map((element, index) => (
+                <Draggable key={element.id} draggableId={element.id} index={index}>
+                  {(dragProvided) => (
+                    <div
+                      className="section-item"
+                      ref={dragProvided.innerRef}
+                      {...dragProvided.draggableProps}
+                      {...dragProvided.dragHandleProps}
+                    >
+                      <span>{element.content}</span>
+                      <button type="button" onClick={() => handleRemoveElement(element.id)} className="link-button danger">
+                        Slett
+                      </button>
+                    </div>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+
+      {error && <p className="form-error">{error}</p>}
+
+      <button type="submit" className="primary-button">
+        Publiser guide
+      </button>
+    </form>
+  );
+};
+
+const GuidesList = ({ guides, onRefresh }) => {
+  const shareBaseUrl = useMemo(() => `${window.location.origin}/guide/`, []);
+
+  return (
+    <div className="guides-card">
+      <div className="guides-header">
+        <h2>Dine guider</h2>
+        <button type="button" onClick={onRefresh} className="link-button">
+          Oppdater
+        </button>
+      </div>
+      {guides.length === 0 ? (
+        <p>Du har ikke laget noen guider enda. Publiser din første guide for å dele den med gjestene dine.</p>
+      ) : (
+        <ul className="guides-list">
+          {guides.map((guide) => (
+            <li key={guide._id} className="guides-item">
+              <div>
+                <h3>{guide.title}</h3>
+                <p className="guide-meta">Sist oppdatert {new Date(guide.updatedAt).toLocaleString('no-NO')}</p>
+                <details>
+                  <summary>Vis seksjoner</summary>
+                  <ol>
+                    {guide.sections.map((section, index) => (
+                      <li key={index}>{section}</li>
+                    ))}
+                  </ol>
+                </details>
+              </div>
+              <div className="guide-actions">
+                <span className="share-label">Delingslenke</span>
+                <input
+                  readOnly
+                  value={`${shareBaseUrl}${guide.slug}`}
+                  onFocus={(event) => event.target.select()}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const Dashboard = ({ user, onLogout }) => {
+  const [guides, setGuides] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const fetchGuides = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const { data } = await api.get('/guides');
+      setGuides(data);
+    } catch (err) {
+      const message = err.response?.data?.message || 'Kunne ikke laste guider.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGuides();
+  }, [fetchGuides]);
+
+  const handleCreate = async ({ title, sections }) => {
+    const { data } = await api.post('/guides', { title, sections });
+    setGuides((prev) => [data, ...prev]);
+    setSuccessMessage('Guiden er publisert! Del lenken med gjestene dine.');
+    setTimeout(() => setSuccessMessage(''), 5000);
+  };
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard-header">
+        <div>
+          <h1>Hei, {user.name}</h1>
+          <p>Bygg og del digitale velkomstguider på minutter.</p>
+        </div>
+        <button type="button" onClick={onLogout} className="link-button">
+          Logg ut
+        </button>
+      </header>
+
+      {successMessage && <div className="success-banner">{successMessage}</div>}
+      {error && <div className="error-banner">{error}</div>}
+
+      <div className="dashboard-grid">
+        <GuideBuilder onCreate={handleCreate} />
+        <div className="guides-column">
+          {loading ? <p>Laster guider...</p> : <GuidesList guides={guides} onRefresh={fetchGuides} />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const PublicGuideView = () => {
+  const { slug } = useParams();
+  const [guide, setGuide] = useState(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchGuide = async () => {
+      try {
+        const { data } = await axios.get(`${API_BASE_URL}/guides/share/${slug}`);
+        setGuide(data);
+      } catch (err) {
+        const message = err.response?.data?.message || 'Guiden ble ikke funnet.';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGuide();
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div className="public-wrapper">
+        <div className="public-card">
+          <p>Laster guide...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="public-wrapper">
+        <div className="public-card">
+          <h1>Fant ikke guiden</h1>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="public-wrapper">
+      <article className="public-card">
+        <header className="public-header">
+          <h1>{guide.title}</h1>
+          {guide.hostName && <p className="public-host">Fra {guide.hostName}</p>}
+          <p className="public-updated">Sist oppdatert {new Date(guide.updatedAt).toLocaleDateString('no-NO')}</p>
+        </header>
+        <ol className="public-sections">
+          {guide.sections.map((section, index) => (
+            <li key={index}>
+              <h2>Seksjon {index + 1}</h2>
+              <p>{section}</p>
+            </li>
+          ))}
+        </ol>
+      </article>
+    </div>
+  );
+};
+
+const AppRoutes = ({ user, onAuthSuccess, onLogout }) => (
+  <Routes>
+    <Route path="/guide/:slug" element={<PublicGuideView />} />
+    <Route
+      path="/"
+      element={user ? <Dashboard user={user} onLogout={onLogout} /> : <AuthView onSuccess={onAuthSuccess} />}
+    />
+    <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+);
+
+const App = () => {
+  const [user, setUser] = useState(() => {
+    const storedUser = localStorage.getItem('user');
+    return storedUser ? JSON.parse(storedUser) : null;
+  });
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('token');
+    if (!storedToken) {
+      return;
+    }
+
+    if (!user) {
+      const storedUser = localStorage.getItem('user');
+      if (storedUser) {
+        setUser(JSON.parse(storedUser));
+      }
+    }
+  }, [user]);
+
+  const handleAuthSuccess = (data) => {
+    localStorage.setItem('token', data.token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+    setUser(data.user);
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    setUser(null);
+  };
+
+  return (
+    <Router>
+      <AppRoutes user={user} onAuthSuccess={handleAuthSuccess} onLogout={handleLogout} />
+    </Router>
+  );
+};
 
 export default App;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,2 +1,26 @@
-/* src/index.css */
-/* La denne være tom foreløpig */
+:root {
+  color: #101828;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #f5f6fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8f9ff 0%, #f1f3ff 60%, #eef2ff 100%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}

--- a/server/models/Guide.js
+++ b/server/models/Guide.js
@@ -1,18 +1,31 @@
 const mongoose = require('mongoose');
 
-const guideSchema = new mongoose.Schema({
-  title: {
-    type: String,
-    required: true,
+const guideSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    sections: {
+      type: [String],
+      default: [],
+    },
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    owner: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
   },
-  content: {
-    type: String,
-    required: true,
+  {
+    timestamps: true,
   },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-});
+);
 
 module.exports = mongoose.model('Guide', guideSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    passwordHash: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,12 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.14.2"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.2.2",
@@ -53,6 +54,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -81,6 +88,12 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -222,6 +235,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -492,6 +514,49 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -500,6 +565,48 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -834,6 +941,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -10,9 +10,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.2"
   },
   "description": ""

--- a/server/server.js
+++ b/server/server.js
@@ -1,74 +1,246 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
 require('dotenv').config();
 
 const Guide = require('./models/Guide');
+const User = require('./models/User');
 
 const app = express();
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret';
 
 app.use(cors());
 app.use(express.json());
 
-mongoose.connect(process.env.MONGODB_URI)
+mongoose
+  .connect(process.env.MONGODB_URI)
   .then(() => console.log('MongoDB tilkoblet'))
   .catch((err) => console.error('MongoDB tilkoblingsfeil:', err));
 
-// Hent alle guider
-app.get('/api/guides', async (req, res) => {
+const authMiddleware = (req, res, next) => {
+  const authorizationHeader = req.headers.authorization || '';
+  const token = authorizationHeader.startsWith('Bearer ')
+    ? authorizationHeader.substring(7)
+    : null;
+
+  if (!token) {
+    return res.status(401).json({ message: 'Innlogging kreves' });
+  }
+
   try {
-    const guides = await Guide.find();
-    res.json(guides);
-  } catch (err) {
-    res.status(500).json({ message: err.message });
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.userId = payload.id;
+    next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Ugyldig eller utløpt token' });
+  }
+};
+
+const sanitizeSections = (sections) => {
+  if (!Array.isArray(sections)) {
+    return [];
+  }
+
+  return sections
+    .map((section) => String(section).trim())
+    .filter((section) => section.length > 0);
+};
+
+const generateUniqueSlug = async () => {
+  let slug;
+  let existingGuide = true;
+
+  while (existingGuide) {
+    slug = crypto.randomBytes(4).toString('hex');
+    existingGuide = await Guide.exists({ slug });
+  }
+
+  return slug;
+};
+
+const buildGuideResponse = (guide) => ({
+  _id: guide._id,
+  title: guide.title,
+  sections: guide.sections,
+  slug: guide.slug,
+  createdAt: guide.createdAt,
+  updatedAt: guide.updatedAt,
+});
+
+app.post('/api/auth/register', async (req, res) => {
+  const { name, email, password } = req.body;
+
+  if (!name || !email || !password) {
+    return res.status(400).json({ message: 'Navn, e-post og passord er påkrevd' });
+  }
+
+  try {
+    const normalizedEmail = email.toLowerCase();
+    const existingUser = await User.findOne({ email: normalizedEmail });
+
+    if (existingUser) {
+      return res.status(409).json({ message: 'E-postadressen er allerede registrert' });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await User.create({
+      name,
+      email: normalizedEmail,
+      passwordHash,
+    });
+
+    const token = jwt.sign({ id: user._id }, JWT_SECRET, { expiresIn: '7d' });
+
+    return res.status(201).json({
+      token,
+      user: { id: user._id, name: user.name, email: user.email },
+    });
+  } catch (error) {
+    console.error('Feil ved registrering:', error);
+    return res.status(500).json({ message: 'Kunne ikke registrere bruker' });
   }
 });
 
-// Lagre en ny guide
-app.post('/api/guides', async (req, res) => {
-  const guide = new Guide({
-    title: req.body.title,
-    content: req.body.content,
-  });
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'E-post og passord er påkrevd' });
+  }
 
   try {
-    const newGuide = await guide.save();
-    res.status(201).json(newGuide);
-  } catch (err) {
-    res.status(400).json({ message: err.message });
+    const normalizedEmail = email.toLowerCase();
+    const user = await User.findOne({ email: normalizedEmail });
+
+    if (!user) {
+      return res.status(401).json({ message: 'Feil e-post eller passord' });
+    }
+
+    const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
+
+    if (!isPasswordValid) {
+      return res.status(401).json({ message: 'Feil e-post eller passord' });
+    }
+
+    const token = jwt.sign({ id: user._id }, JWT_SECRET, { expiresIn: '7d' });
+
+    return res.json({
+      token,
+      user: { id: user._id, name: user.name, email: user.email },
+    });
+  } catch (error) {
+    console.error('Feil ved innlogging:', error);
+    return res.status(500).json({ message: 'Kunne ikke logge inn' });
   }
 });
 
-// Oppdater en eksisterende guide
-app.put('/api/guides/:id', async (req, res) => {
+app.get('/api/guides', authMiddleware, async (req, res) => {
   try {
-    const guide = await Guide.findById(req.params.id);
+    const guides = await Guide.find({ owner: req.userId }).sort({ updatedAt: -1 });
+    return res.json(guides.map((guide) => buildGuideResponse(guide)));
+  } catch (error) {
+    console.error('Feil ved henting av guider:', error);
+    return res.status(500).json({ message: 'Kunne ikke hente guider' });
+  }
+});
+
+app.post('/api/guides', authMiddleware, async (req, res) => {
+  const { title, sections } = req.body;
+
+  if (!title) {
+    return res.status(400).json({ message: 'Tittel er påkrevd' });
+  }
+
+  const cleanedSections = sanitizeSections(sections);
+
+  if (cleanedSections.length === 0) {
+    return res.status(400).json({ message: 'Legg til minst én seksjon i guiden' });
+  }
+
+  try {
+    const slug = await generateUniqueSlug();
+    const guide = await Guide.create({
+      title,
+      sections: cleanedSections,
+      slug,
+      owner: req.userId,
+    });
+
+    return res.status(201).json(buildGuideResponse(guide));
+  } catch (error) {
+    console.error('Feil ved opprettelse av guide:', error);
+    return res.status(500).json({ message: 'Kunne ikke opprette guide' });
+  }
+});
+
+app.put('/api/guides/:id', authMiddleware, async (req, res) => {
+  const { id } = req.params;
+  const { title, sections } = req.body;
+
+  try {
+    const guide = await Guide.findOne({ _id: id, owner: req.userId });
+
     if (!guide) {
       return res.status(404).json({ message: 'Guide ikke funnet' });
     }
 
-    guide.title = req.body.title || guide.title;
-    guide.content = req.body.content || guide.content;
+    if (title) {
+      guide.title = title;
+    }
+
+    if (sections) {
+      guide.sections = sanitizeSections(sections);
+    }
 
     const updatedGuide = await guide.save();
-    res.json(updatedGuide);
-  } catch (err) {
-    res.status(400).json({ message: err.message });
+    return res.json(buildGuideResponse(updatedGuide));
+  } catch (error) {
+    console.error('Feil ved oppdatering av guide:', error);
+    return res.status(500).json({ message: 'Kunne ikke oppdatere guide' });
   }
 });
 
-// Slett en guide
-app.delete('/api/guides/:id', async (req, res) => {
+app.delete('/api/guides/:id', authMiddleware, async (req, res) => {
+  const { id } = req.params;
+
   try {
-    const guide = await Guide.findById(req.params.id);
+    const guide = await Guide.findOne({ _id: id, owner: req.userId });
+
     if (!guide) {
       return res.status(404).json({ message: 'Guide ikke funnet' });
     }
 
     await guide.deleteOne();
-    res.json({ message: 'Guide slettet' });
-  } catch (err) {
-    res.status(500).json({ message: err.message });
+    return res.json({ message: 'Guide slettet' });
+  } catch (error) {
+    console.error('Feil ved sletting av guide:', error);
+    return res.status(500).json({ message: 'Kunne ikke slette guide' });
+  }
+});
+
+app.get('/api/guides/share/:slug', async (req, res) => {
+  const { slug } = req.params;
+
+  try {
+    const guide = await Guide.findOne({ slug }).populate('owner', 'name');
+
+    if (!guide) {
+      return res.status(404).json({ message: 'Guide ikke funnet' });
+    }
+
+    return res.json({
+      title: guide.title,
+      sections: guide.sections,
+      slug: guide.slug,
+      hostName: guide.owner?.name,
+      updatedAt: guide.updatedAt,
+    });
+  } catch (error) {
+    console.error('Feil ved deling av guide:', error);
+    return res.status(500).json({ message: 'Kunne ikke hente delt guide' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add user accounts, JWT authentication, and shareable guide endpoints with slugs
- create front-end dashboard with login/registration, guide builder, and public viewer
- refresh styling and configuration for the SaaS experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1285b4e9c83249813c4a424085491